### PR TITLE
feat: Create NextLinkAnchor component

### DIFF
--- a/src/components/atoms/NextLinkAnchor/NextLinkAnchor.jsx
+++ b/src/components/atoms/NextLinkAnchor/NextLinkAnchor.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import NextLink from 'next/link';
+
+/**
+ * HOC that will be passed into another component to create a NextLink
+ *
+ * @param {Object} props
+ * @param {Element} ref
+ */
+function NextLinkAnchor(props, ref) {
+  const {
+    to,
+    linkAs,
+    replace,
+    scroll,
+    shallow,
+    prefetch,
+    locale,
+    ...attributes
+  } = props;
+
+  return (
+    <NextLink
+      href={to}
+      prefetch={prefetch}
+      as={linkAs}
+      replace={replace}
+      scroll={scroll}
+      shallow={shallow}
+      passHref
+      locale={locale}
+    >
+      <a ref={ref} {...attributes} />
+    </NextLink>
+  );
+}
+
+export default React.forwardRef(NextLinkAnchor);
+
+const propsShape = {
+  /**
+   * The path or URL to navigate to.
+   */
+  to: PropTypes.string.isRequired,
+
+  /**
+   * Optional HTML attributes for the <a /> tag
+   */
+  attributes: PropTypes.object,
+
+  /**
+   * Optional decorator for the path that will be shown in the browser URL bar.
+   */
+  linkAs: PropTypes.string,
+
+  /**
+   * Allows for providing a different locale.
+   */
+  locale: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+
+  /**
+   * Prefetch the page in the background.
+   */
+  prefetch: PropTypes.bool,
+
+  /**
+   * Replace the current history state instead of adding a new url into the stack.
+   */
+  replace: PropTypes.bool,
+
+  /**
+   * Scroll to the top of the page after a navigation.
+   */
+  scroll: PropTypes.bool,
+
+  /**
+   * Update the path of the current page without rerunning getStaticProps, getServerSideProps or getInitialProps.
+   */
+  shallow: PropTypes.bool,
+};
+
+NextLinkAnchor.propTypes = {
+  props: PropTypes.shape(propsShape).isRequired,
+  ref: PropTypes.element,
+};

--- a/src/components/atoms/NextLinkAnchor/index.js
+++ b/src/components/atoms/NextLinkAnchor/index.js
@@ -1,0 +1,1 @@
+export { default } from './NextLinkAnchor';

--- a/src/components/atoms/index.js
+++ b/src/components/atoms/index.js
@@ -1,0 +1,1 @@
+export { default as NextLinkAnchor } from './NextLinkAnchor';


### PR DESCRIPTION
@1jeanpaul1 This is a High Order Component that combines Next/Link and React.ref. This component allows Next/Link to function correctly when a NextLink is passed into a react component using props. I would like to have this in origin/dev tomorrow when I review AbstractDevs code, so I can show him how to correctly create Button links. 